### PR TITLE
Associate projects with users 113319039

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
 class ApplicationController < Xing::Controllers::Base
-
+  rescue_from CanCan::AccessDenied do |exception|
+    render json: {}, status: 401
+  end
 end

--- a/backend/app/controllers/projects_controller.rb
+++ b/backend/app/controllers/projects_controller.rb
@@ -15,7 +15,10 @@ class ProjectsController < ApplicationController
   #PUT /projects/{id}
   def update
     project = Project.find(params[:id])
+    authorize! :edit, project
     mapper = ProjectMapper.new(json_body, project.id)
+    mapper.perform_mapping
+    authorize! :edit, mapper.project
 
     if mapper.save
       render :json => ProjectSerializer.new(mapper.project)

--- a/backend/app/controllers/projects_controller.rb
+++ b/backend/app/controllers/projects_controller.rb
@@ -14,7 +14,9 @@ class ProjectsController < ApplicationController
 
   # POST /projects
   def create
-    mapper = ProjectMapper.new(parse_json)
+    mapper = ProjectMapper.new(json_body)
+    mapper.perform_mapping
+    authorize! :create, mapper.project
 
     if mapper.save
       successful_create(project_path(mapper.project))

--- a/backend/app/models/ability.rb
+++ b/backend/app/models/ability.rb
@@ -6,8 +6,6 @@ class Ability
       user.role.set_abilities(self)
 
       # add common abilies to logged_in users
-      can :create, Project
-      can :manage, Project, user_id: user.id
     else
       # add common abilities to public users here
       can :read, Project

--- a/backend/app/models/ability.rb
+++ b/backend/app/models/ability.rb
@@ -6,8 +6,11 @@ class Ability
       user.role.set_abilities(self)
 
       # add common abilies to logged_in users
+      can :create, Project
+      can :manage, Project, user_id: user.id
     else
       # add common abilities to public users here
+      can :read, Project
     end
   end
 end

--- a/backend/app/models/ability.rb
+++ b/backend/app/models/ability.rb
@@ -6,6 +6,7 @@ class Ability
       user.role.set_abilities(self)
 
       # add common abilies to logged_in users
+      can :read, Project
     else
       # add common abilities to public users here
       can :read, Project

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -1,2 +1,5 @@
 class Project < ActiveRecord::Base
+  belongs_to :user
+
+  # Not validating for presence of user because of preexisting sample data.
 end

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -1,5 +1,5 @@
 class Project < ActiveRecord::Base
   belongs_to :user
 
-  # Not validating for presence of user because of preexisting sample data.
+  validates :user, presence: true
 end

--- a/backend/app/models/role/admin.rb
+++ b/backend/app/models/role/admin.rb
@@ -3,6 +3,7 @@ class Role::Admin < Role
 
   def set_abilities(ability)
     ability.can :manage, User
+    ability.can :manage, Project
   end
 
 end

--- a/backend/app/models/role/registered_user.rb
+++ b/backend/app/models/role/registered_user.rb
@@ -2,7 +2,6 @@ class Role::RegisteredUser < Role
   Role.register 'RegisteredUser', self
 
   def set_abilities(ability)
-    ability.can :read, Project
     ability.can :manage, Project, user_id: user.id
   end
 

--- a/backend/app/models/role/registered_user.rb
+++ b/backend/app/models/role/registered_user.rb
@@ -1,0 +1,9 @@
+class Role::RegisteredUser < Role
+  Role.register 'RegisteredUser', self
+
+  def set_abilities(ability)
+    ability.can :read, Project
+    ability.can :manage, Project, user_id: user.id
+  end
+
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -31,6 +31,8 @@
 class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable, :rememberable, :trackable, :validatable, :confirmable, :recoverable, :token_authenticatable
 
+  has_many :projects
+
   def role
     @role    ||= Role.for(self)
   end

--- a/backend/app/serializers/project_serializer.rb
+++ b/backend/app/serializers/project_serializer.rb
@@ -1,8 +1,12 @@
 class ProjectSerializer < Xing::Serializers::Base
-  attributes :name, :description, :deadline, :goal
+  attributes :name, :description, :deadline, :goal, :user_id
 
   def goal
     sprintf("%.2f", object.goal)
+  end
+
+  def user_id
+    object.user.id
   end
 
   def links

--- a/backend/db/migrate/20160210211027_add_user_to_projects.rb
+++ b/backend/db/migrate/20160210211027_add_user_to_projects.rb
@@ -1,0 +1,5 @@
+class AddUserToProjects < ActiveRecord::Migration
+  def change
+    add_reference :projects, :user, index: true, foreign_key: true
+  end
+end

--- a/backend/db/sample_data/projects.rake
+++ b/backend/db/sample_data/projects.rake
@@ -15,7 +15,8 @@ namespace :db do
             :name =>        Faker::Lorem.words(2..5).join(" ").titleize,
             :description => Faker::Lorem.sentences(1..6).join(" "),
             :deadline =>    (Date.today + rand(20).days).end_of_day,
-            :goal =>        (2 + rand(20)) * 5000.00
+            :goal =>        (2 + rand(20)) * 5000.00,
+            :user =>        User.first
           )
         end
       end

--- a/backend/spec/factories/projects.rb
+++ b/backend/spec/factories/projects.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
     description "A neat new integrated web development platform."
     deadline Date.today + 30.days
     goal 20000.00
+    association :user
   end
 end

--- a/backend/spec/factories/users_factory.rb
+++ b/backend/spec/factories/users_factory.rb
@@ -21,7 +21,9 @@ FactoryGirl.define do
     confirmed_at Time.now
   end
 
-  factory :user, :parent => :raw_user, :traits => [:confirmed]
+  factory :user, :parent => :raw_user, :traits => [:confirmed] do
+    role_name 'RegisteredUser'
+  end
 
   factory :unconfirmed_user, :parent => :raw_user
   factory :confirmed_user, :parent => :user, :traits => [:confirmed]

--- a/backend/spec/features/user_creates_a_project_spec.rb
+++ b/backend/spec/features/user_creates_a_project_spec.rb
@@ -19,7 +19,7 @@ RSpec.steps "Visitor Creates a New Project", js: :true, vcr: {} do
   end
 
   let :goal do
-    31415.92
+    31415
   end
 
   it "visits root" do
@@ -61,7 +61,7 @@ RSpec.steps "Visitor Creates a New Project", js: :true, vcr: {} do
     click_button "Save"
   end
 
-  skip "redirects to project detail page" do
+  it "redirects to project detail page" do
     expect(page).to have_content("Pie in the Sky")
   end
 end

--- a/backend/spec/features/user_creates_a_project_spec.rb
+++ b/backend/spec/features/user_creates_a_project_spec.rb
@@ -2,6 +2,10 @@ require "spec_helper"
 
 RSpec.steps "Visitor Creates a New Project", js: :true, vcr: {} do
 
+  before :all do
+    @user = FactoryGirl.create(:user)
+  end
+
   let :name do
     "Pie in the Sky"
   end
@@ -20,9 +24,21 @@ RSpec.steps "Visitor Creates a New Project", js: :true, vcr: {} do
 
   it "visits root" do
     visit "/"
+    expect(page).to have_content("Below you can see the list")
   end
 
-  it "is on the homepage" do
+  it "does not display the new-project button" do
+    expect(page).not_to have_content("Create a New Project")
+  end
+
+  perform_steps "sign in with"
+
+  it "visits root" do
+    visit "/"
+    expect(page).to have_content("Below you can see the list")
+  end
+
+  it "does display the new-project button" do
     expect(page).to have_content("Create a New Project")
   end
 

--- a/backend/spec/features/user_creates_a_project_spec.rb
+++ b/backend/spec/features/user_creates_a_project_spec.rb
@@ -61,7 +61,7 @@ RSpec.steps "Visitor Creates a New Project", js: :true, vcr: {} do
     click_button "Save"
   end
 
-  it "redirects to project detail page" do
+  skip "redirects to project detail page" do
     expect(page).to have_content("Pie in the Sky")
   end
 end

--- a/backend/spec/features/user_creates_a_project_spec.rb
+++ b/backend/spec/features/user_creates_a_project_spec.rb
@@ -19,7 +19,7 @@ RSpec.steps "Visitor Creates a New Project", js: :true, vcr: {} do
   end
 
   let :goal do
-    31415
+    31415.92
   end
 
   it "visits root" do
@@ -63,5 +63,6 @@ RSpec.steps "Visitor Creates a New Project", js: :true, vcr: {} do
 
   it "redirects to project detail page" do
     expect(page).to have_content("Pie in the Sky")
+    expect(page).not_to have_content("New Project")
   end
 end

--- a/backend/spec/features/user_edits_project.rb
+++ b/backend/spec/features/user_edits_project.rb
@@ -2,11 +2,34 @@ require "spec_helper"
 
 RSpec.steps "Visitor Creates a New Project", js: :true, vcr: {} do
   before :all do
-    @user = FactoryGirl.build(:user)
+    @user = FactoryGirl.create(:user)
     @project = FactoryGirl.create(:project,
                                  :name => "Xing Framework",
-                                 :description => "Cool")
+                                 :description => "Cool",
+                                 :user => @user)
   end
+
+  it "visits root" do
+    visit "/"
+  end
+
+  it "shows a list of projects" do
+    expect(page).to have_content("Xing Framework")
+  end
+
+  it "clicks on a project" do
+    click_link("View")
+  end
+
+  it "shows the experience page" do
+    expect(page).to have_content("Cool")
+  end
+
+  it "does not display the edit button" do
+    expect(page).not_to have_content("Edit Project")
+  end
+
+  perform_steps "sign in with"
 
   it "visits root" do
     visit "/"

--- a/backend/spec/mappers/project_mapper_spec.rb
+++ b/backend/spec/mappers/project_mapper_spec.rb
@@ -6,6 +6,10 @@ describe ProjectMapper, type: :mapper do
     Time.utc(2015, 3, 14, 9, 27)
   end
 
+  let :user do
+    FactoryGirl.create(:user)
+  end
+
   let :valid_data do
     {
       links: {
@@ -15,7 +19,8 @@ describe ProjectMapper, type: :mapper do
         name: "User-Created Project",
         description: "This information was sent from the frontend",
         deadline: time,
-        goal: 30000.00
+        goal: 30000.00,
+        user_id: user.id,
         }
       }
   end

--- a/backend/spec/mappers/project_mapper_spec.rb
+++ b/backend/spec/mappers/project_mapper_spec.rb
@@ -25,30 +25,75 @@ describe ProjectMapper, type: :mapper do
       }
   end
 
-  describe "saving a new project" do
-    let :json do
-      valid_data.to_json
-    end
+  let :invalid_data do
+    {
+      links: {
+        self: "",
+        },
+      data: {
+        name: "User-Created Project",
+        description: "This information was sent from the frontend",
+        deadline: time,
+        goal: 30000.00
+        }
+      }
+  end
 
+  describe "saving a new project," do
     let :mapper do
       ProjectMapper.new(json)
     end
 
-    it "saves the project" do
-      expect do
+    describe "when successful," do
+      let :json do
+        valid_data.to_json
+      end
+
+      it "saves the project" do
+        expect do
+          mapper.save
+        end.to change{ Project.count }.by(1)
+      end
+
+      it "returns as truthy" do
+        expect(mapper.save).to be_truthy
+      end
+
+      it "allows the mapper to return the saved project" do
         mapper.save
-      end.to change{ Project.count }.by(1)
+        expect(mapper.project).to be_a(Project)
+        expect(mapper.project).to be_persisted
+        expect(mapper.project.name).to eq("User-Created Project")
+      end
     end
 
-    it "returns as truthy" do
-      expect(mapper.save).to be_truthy
-    end
+    describe "when unsuccessful," do
+      let :json do
+        invalid_data.to_json
+      end
 
-    it "allows the mapper to return the saved project" do
-      mapper.save
-      expect(mapper.project).to be_a(Project)
-      expect(mapper.project).to be_persisted
-      expect(mapper.project.name).to eq("User-Created Project")
+      it "does not save the project" do
+        expect do
+          mapper.save
+        end.not_to change{ Project.count }
+      end
+
+      it "returns as falsey" do
+        expect(mapper.save).to be_falsey
+      end
+
+      it "adds errors to the mapper" do
+        mapper.save
+
+        expect(mapper.errors).to eq({
+          data: {
+            user: {
+              type: "required",
+              message: "can't be blank"
+              }
+            }
+          })
+      end
     end
   end
 end

--- a/backend/spec/requests/project_create_spec.rb
+++ b/backend/spec/requests/project_create_spec.rb
@@ -30,6 +30,7 @@ describe "POST /projects", type: :request do
         description: "This information was sent from the frontend",
         deadline: Time.now + 3.days,
         goal: 30000.00,
+        user_id: user.id + 1,
       }
     }
   end
@@ -52,16 +53,15 @@ describe "POST /projects", type: :request do
       end
     end
 
-    context "on an unsuccessful create" do
+    context "with an incorrect user_id" do
       let :data do
         invalid_data
       end
 
-      it "returns a 422 with errors in the body" do
+      it "returns a 401 (unauthorized)" do
         authenticated_json_post user, "projects/", json_body
 
-        expect(response.status).to eq(422)
-        expect(response.body).to be_json_eql("\"can't be blank\"").at_path("data/user/message")
+        expect(response.status).to eq(401)
       end
     end
   end

--- a/backend/spec/requests/project_create_spec.rb
+++ b/backend/spec/requests/project_create_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 describe "POST /projects", type: :request do
+  let :user do
+    FactoryGirl.create(:user)
+  end
+
   let :valid_data do
     {
       links: {
@@ -10,7 +14,8 @@ describe "POST /projects", type: :request do
         name: "User-Created Project",
         description: "This information was sent from the frontend",
         deadline: Time.now + 3.days,
-        goal: 30000.00
+        goal: 30000.00,
+        user_id: user.id,
       }
     }
   end

--- a/backend/spec/requests/project_create_spec.rb
+++ b/backend/spec/requests/project_create_spec.rb
@@ -20,21 +20,61 @@ describe "POST /projects", type: :request do
     }
   end
 
+  let :invalid_data do
+    {
+      links: {
+        self: ""
+      },
+      data: {
+        name: "User-Created Project",
+        description: "This information was sent from the frontend",
+        deadline: Time.now + 3.days,
+        goal: 30000.00,
+      }
+    }
+  end
+
   let :json_body do
     data.to_json
   end
 
-  context "on a successful create" do
+  context "when logged in" do
+    context "on a successful create" do
+      let :data do
+        valid_data
+      end
+
+      it "returns 201 with the new address in the header 'Location'" do
+        authenticated_json_post user, "projects/", json_body
+        expect(response.status).to eq(201)
+        expect(response.headers["Location"]).
+          to eq(project_path(Project.find_by(name: "User-Created Project")))
+      end
+    end
+
+    context "on an unsuccessful create" do
+      let :data do
+        invalid_data
+      end
+
+      it "returns a 422 with errors in the body" do
+        authenticated_json_post user, "projects/", json_body
+
+        expect(response.status).to eq(422)
+        expect(response.body).to be_json_eql("\"can't be blank\"").at_path("data/user/message")
+      end
+    end
+  end
+
+  context "when not logged in" do
     let :data do
       valid_data
     end
 
-    it "returns 201 with the new address in the header 'Location'" do
+    it "returns a 401" do
       json_post "projects/", json_body
-      expect(response.status).to eq(201)
-      expect(response.headers["Location"]).
-        to eq(project_path(Project.find_by(name: "User-Created Project")))
+
+      expect(response.status).to eq(401)
     end
   end
-
 end

--- a/backend/spec/requests/project_update_spec.rb
+++ b/backend/spec/requests/project_update_spec.rb
@@ -6,11 +6,14 @@ describe "project#update", :type => :request do
                                       :name => "The Xing Framework",
                                       :description => "Pretty cool framework!",
                                       :deadline => Date.today + 30.days,
-                                      :goal => 20000.00
+                                      :goal => 20000.00,
+                                      :user => user
                                      )
   end
 
   let :user do FactoryGirl.create(:user) end
+
+  let :other_user do FactoryGirl.create(:user) end
 
   let :valid_data do
     {
@@ -27,34 +30,67 @@ describe "project#update", :type => :request do
     "/projects/#{project.id}"
   end
 
-  describe "Successful update" do
-    describe 'PUT projects/#{project.id}' do
-      let :json do valid_data.to_json end
+  describe "when logged in as owner" do
+    describe "Successful update" do
+      describe 'PUT projects/#{project.id}' do
+        let :json do valid_data.to_json end
 
-      it "is a 200 success including the serialized object" do
+        it "is a 200 success including the serialized object" do
 
-        json_put resource_url, json
+          authenticated_json_put user, resource_url, json
 
-        expect(response).to be_success
+          expect(response).to be_success
 
-        body = response.body
+          body = response.body
 
-        expect(body).to have_json_path("links")
-        expect(body).to have_json_path("links/self")
-        expect(body).to have_json_path("data")
-        expect(body).to have_json_path("data/name")
-        expect(body).to have_json_path("data/description")
-        expect(body).to have_json_path("data/deadline")
-        expect(body).to have_json_path("data/goal")
-      end
+          expect(body).to have_json_path("links")
+          expect(body).to have_json_path("links/self")
+          expect(body).to have_json_path("data")
+          expect(body).to have_json_path("data/name")
+          expect(body).to have_json_path("data/description")
+          expect(body).to have_json_path("data/deadline")
+          expect(body).to have_json_path("data/goal")
+        end
 
-      it "should update information" do
-        expect do
-          json_put resource_url, json
-        end.to change { project.reload.name }.to("Xing Rules")
+        it "should update information" do
+          expect do
+            authenticated_json_put user, resource_url, json
+          end.to change { project.reload.name }.to("Xing Rules")
+        end
       end
     end
   end
+
+  describe "when logged in as another user" do
+    let :json do valid_data.to_json end
+
+    it "returns a 401" do
+      authenticated_json_put other_user, resource_url, json
+
+      expect(response.status).to eq(401)
+    end
+
+    it "does not update the record" do
+      expect do
+        authenticated_json_put other_user, resource_url, json
+      end.not_to change { project.reload.name }
+    end
+  end
+
+  describe "when not logged in" do
+    let :json do valid_data.to_json end
+
+    it "returns a 401" do
+      json_put resource_url, json
+
+      expect(response.status).to eq(401)
+    end
+
+    it "does not update the record" do
+      expect do
+        json_put resource_url, json
+      end.not_to change { project.reload.name }
+    end
+  end
+
 end
-
-

--- a/backend/spec/serializers/project_list_serializer_spec.rb
+++ b/backend/spec/serializers/project_list_serializer_spec.rb
@@ -5,21 +5,21 @@ describe ProjectListSerializer, :type => :serializer do
   let! :project_1 do
     FactoryGirl.create(:project,
                        :name => "The Xing Framework",
-                       :description => "Cool new web framework!"
+                       :description => "Cool new web framework!",
                       )
   end
 
   let! :project_2 do
     FactoryGirl.create(:project,
                        :name => "The Xing Book",
-                       :description => "A book!"
+                       :description => "A book!",
                       )
   end
 
   let! :project_3 do
     FactoryGirl.create(:project,
                        :name => "The Xing Screencasts",
-                       :description => "Screencasts!"
+                       :description => "Screencasts!",
                       )
   end
 
@@ -35,23 +35,32 @@ describe ProjectListSerializer, :type => :serializer do
     end
 
     it "should have the correct structure and content" do
-      expect(json).to be_json_string("/projects/#{project_1.id}").at_path("data/0/links/self")
-      expect(json).to be_json_string("The Xing Framework")       .at_path("data/0/data/name")
+      expect(json).to be_json_string("/projects/#{project_1.id}").
+                      at_path("data/0/links/self")
+      expect(json).to be_json_string("The Xing Framework").
+                      at_path("data/0/data/name")
       expect(json).not_to have_json_path("data/0/data/description")
       expect(json).not_to have_json_path("data/0/data/deadline")
       expect(json).not_to have_json_path("data/0/data/goal")
+      expect(json).not_to have_json_path("data/0/data/user_id")
 
-      expect(json).to be_json_string("/projects/#{project_2.id}").at_path("data/1/links/self")
-      expect(json).to be_json_string("The Xing Book")            .at_path("data/1/data/name")
+      expect(json).to be_json_string("/projects/#{project_2.id}").
+                      at_path("data/1/links/self")
+      expect(json).to be_json_string("The Xing Book").
+                      at_path("data/1/data/name")
       expect(json).not_to have_json_path("data/1/data/description")
       expect(json).not_to have_json_path("data/1/data/deadline")
       expect(json).not_to have_json_path("data/1/data/goal")
+      expect(json).not_to have_json_path("data/1/data/user_id")
 
-      expect(json).to be_json_string("/projects/#{project_3.id}").at_path("data/2/links/self")
-      expect(json).to be_json_string("The Xing Screencasts")     .at_path("data/2/data/name")
+      expect(json).to be_json_string("/projects/#{project_3.id}").
+                      at_path("data/2/links/self")
+      expect(json).to be_json_string("The Xing Screencasts").
+                      at_path("data/2/data/name")
       expect(json).not_to have_json_path("data/2/data/description")
       expect(json).not_to have_json_path("data/2/data/deadline")
       expect(json).not_to have_json_path("data/2/data/goal")
+      expect(json).not_to have_json_path("data/2/data/user_id")
 
       # the project descriptions do not appear anywhere in this resource
       expect(json).not_to be_json_string("Cool new web framework!")

--- a/backend/spec/serializers/project_serializer_spec.rb
+++ b/backend/spec/serializers/project_serializer_spec.rb
@@ -2,12 +2,17 @@ require 'spec_helper'
 
 describe ProjectSerializer, :type => :serializer do
 
+  let :user do
+    FactoryGirl.create(:user)
+  end
+
   let! :project do
     FactoryGirl.create(:project,
                        :name => "The Xing Framework",
                        :description => "Cool new web framework!",
                        :deadline => Date.today + 30.days,
-                       :goal => 15000.00
+                       :goal => 15000.00,
+                       :user => user
                       )
   end
 
@@ -19,14 +24,22 @@ describe ProjectSerializer, :type => :serializer do
     let :json do serializer.to_json end
 
     it "should have the correct links" do
-      expect(json).to be_json_string("/projects/#{project.id}").at_path("links/self")
+      expect(json).to be_json_string("/projects/#{project.id}").
+        at_path("links/self")
     end
 
     it "should have the correct structure and content" do
-      expect(json).to be_json_string("The Xing Framework").at_path("data/name")
-      expect(json).to be_json_string("Cool new web framework!").at_path("data/description")
-      expect(json).to be_json_string(project.deadline.as_json).at_path("data/deadline")
-      expect(json).to be_json_string("15000.00").at_path("data/goal")
+      expect(json).to be_json_string("The Xing Framework").
+        at_path("data/name")
+      expect(json).to be_json_string("Cool new web framework!").
+        at_path("data/description")
+      expect(json).to be_json_string(project.deadline.as_json).
+        at_path("data/deadline")
+      expect(json).to be_json_string("15000.00").
+        at_path("data/goal")
+      expect(json).to be_json_eql(user.id).
+        at_path("data/user_id")
+
     end
   end
 end

--- a/backend/spec/support/session_helpers.rb
+++ b/backend/spec/support/session_helpers.rb
@@ -63,5 +63,6 @@ RSpec.shared_steps "sign in with" do
 
   it "clicks Sign In" do
     click_button "Sign In"
+    expect(page).to have_xpath('//a[./text() = "Sign Out"]')
   end
 end

--- a/frontend/src/app/app.js
+++ b/frontend/src/app/app.js
@@ -25,6 +25,7 @@ import * as RootStates from './rootStates.js';
 import RootCtrl from './rootController.js';
 
 import Resources from "common/resources.js";
+import CurrentUser from "common/currentUser.js";
 
 import Projects from "./projects/project.js";
 
@@ -46,6 +47,7 @@ var app = new Module(appName, [
   RootStates,
   RootCtrl,
   Resources,
+  CurrentUser,
   Projects
 ]);
 

--- a/frontend/src/app/homepage/homepage-show.tpl.html
+++ b/frontend/src/app/homepage/homepage-show.tpl.html
@@ -13,6 +13,6 @@
   </tr>
 </table>
 
-<button ui-sref="root.inner.projectNew">
+<button ng-show="homepageShow.currentUser.user" ui-sref="root.inner.projectNew">
   Create a New Project
 </button>

--- a/frontend/src/app/homepage/homepageControllers.js
+++ b/frontend/src/app/homepage/homepageControllers.js
@@ -1,9 +1,10 @@
 import {Controller} from 'a1atscript';
 
-@Controller('HomepageShowCtrl', ['projects'])
+@Controller('HomepageShowCtrl', ['projects', 'CurrentUser'])
 export class HomepageShowController {
-  constructor(projects) {
+  constructor(projects, currentUser) {
     this.projects = projects;
+    this.currentUser = currentUser;
   }
 }
 

--- a/frontend/src/app/projects/project.tpl.html
+++ b/frontend/src/app/projects/project.tpl.html
@@ -5,13 +5,13 @@
   <dd>{{projectCtrl.project.description}}</dd>
 
   <dt>Deadline</dt>
-  <dd>{{projectCtrl.project.deadline}}</dd>
+  <dd>{{projectCtrl.project.deadline | date:"medium"}}</dd>
 
   <dt>Goal</dt>
-  <dd>{{projectCtrl.project.goal}}</dd>
+  <dd>{{projectCtrl.project.goal | currency : "$" : 2}}</dd>
 </dl>
 
-<button ng-click="projectCtrl.edit()">
+<button ng-click="projectCtrl.edit()" ng-show="projectCtrl.currentUserCanEdit()">
   Edit Project
 </button>
 <a ui-sref="root.homepage.show">Home</a>

--- a/frontend/src/app/projects/projectsControllers.js
+++ b/frontend/src/app/projects/projectsControllers.js
@@ -1,11 +1,16 @@
 import {Controller} from 'a1atscript';
 
-@Controller('ProjectCtrl', ['project', '$state'])
+@Controller('ProjectCtrl', ['project', '$state', 'CurrentUser'])
 export class ProjectController {
-  constructor(project, $state) {
+  constructor(project, $state, currentUser) {
     this.project = project;
     this.$state = $state;
+    this.currentUser = currentUser;
     this.formTemplate = 'projects/_form.tpl.html';
+  }
+
+  currentUserCanEdit() {
+    return this.currentUser.user && this.currentUser.user.id == this.project.userId
   }
 
   edit() {

--- a/frontend/src/app/projects/projectsControllers.js
+++ b/frontend/src/app/projects/projectsControllers.js
@@ -6,7 +6,6 @@ export class ProjectController {
     this.project = project;
     this.$state = $state;
     this.currentUser = currentUser;
-    this.formTemplate = 'projects/_form.tpl.html';
   }
 
   currentUserCanEdit() {

--- a/frontend/src/app/projects/projectsControllers.js
+++ b/frontend/src/app/projects/projectsControllers.js
@@ -7,19 +7,21 @@ export class ProjectsController {
   }
 }
 
-@Controller("ProjectNewCtrl", ["resources", "$state"])
+@Controller("ProjectNewCtrl", ["resources", "$state", "CurrentUser"])
 export class ProjectNewController {
-  constructor(resources, $state) {
+  constructor(resources, $state, currentUser) {
     this.resources = resources;
     this.$state = $state;
+    this.currentUser = currentUser;
     this.project = this.resources.projects().new();
     this.formTemplate = 'projects/_form.tpl.html';
   }
 
   save() {
+    this.project.userId = this.currentUser.user.id;
     this.resources.projects().create(this.project).then((project) => {
       this.project = project;
-      this.$state.go("root.inner.project", {id: this.project.shortLink})
+      this.$state.go("root.inner.project", {id: this.project.shortLink});
     });
   }
 }

--- a/frontend/src/common/currentUser.js
+++ b/frontend/src/common/currentUser.js
@@ -1,0 +1,18 @@
+import {Service} from "a1atscript";
+
+@Service('CurrentUser', ["$rootScope", "$auth"])
+export default class CurrentUser {
+  constructor($rootScope, $auth) {
+    this.$rootScope = $rootScope;
+    this.$auth = $auth;
+    this.$auth.validateUser().then((user) => {
+      this.user = user;
+    });
+    this.$rootScope.$on('auth:login-success', (ev, user) => {
+      this.user = user;
+    });
+    this.$rootScope.$on('auth:logout-success', (ev, user) => {
+      this.user = null;
+    });
+  }
+}

--- a/frontend/src/common/resources/Project.js
+++ b/frontend/src/common/resources/Project.js
@@ -6,4 +6,5 @@ RL.Describe(Project, (desc) => {
   desc.property("description", "");
   desc.property("deadline", "");
   desc.property("goal", "");
+  desc.property("userId", 0);
 });

--- a/frontend/test/projects/projectsControllers.js
+++ b/frontend/test/projects/projectsControllers.js
@@ -1,10 +1,75 @@
-import { ProjectEditController, ProjectNewController } from "../../src/app/projects/projectsControllers.js";
+import { ProjectController, ProjectEditController, ProjectNewController }
+  from "../../src/app/projects/projectsControllers.js";
 
 describe('Projects Controllers', function() {
+    var controller
+
+  describe("ProjectController", function(){
+    var mockProject, mockState, mockCurrentUser;
+
+    beforeEach(function() {
+      mockProject = {};
+      mockState = jasmine.createSpyObj("mockState", ["go"]);
+      mockCurrentUser = {}
+
+      controller = new ProjectController(mockProject, mockState, mockCurrentUser)
+    });
+
+    describe("edit()", function() {
+      it("calls go with the correct arguments", function() {
+        controller.project = {shortLink: "777"}
+
+        controller.edit();
+
+        expect(mockState.go).
+          toHaveBeenCalledWith("root.inner.projectEdit", {id: "777"});
+      });
+    });
+
+    describe("currentUserCanEdit(),", function() {
+      describe("when current user is falsy,", function() {
+        beforeEach(function() {
+          controller.currentUser = { user: null };
+          controller.project = { userId: 23 }
+        });
+
+        it ("returns falsy", function() {
+          expect(controller.currentUserCanEdit()).toBeFalsy();
+        });
+      });
+
+      describe("when current user is present", function() {
+        beforeEach(function() {
+          controller.currentUser = {
+            user: { id: 23 }
+          };
+        });
+
+        describe("and matches the project's user,", function() {
+          beforeEach(function() {
+            controller.project = { userId: 23 };
+          });
+
+          it("returns true", function() {
+            expect(controller.currentUserCanEdit()).toEqual(true);
+          });
+        });
+
+        describe("and doesn't match the project's user,", function() {
+          beforeEach(function() {
+            controller.project = { userId: 42 };
+          });
+
+          it("returns false", function() {
+            expect(controller.currentUserCanEdit()).toEqual(false);
+          });
+        });
+      });
+    });
+  });
 
   describe('ProjectEditController', function() {
-    var controller,
-        mockProject,
+    var mockProject,
         mockState;
 
     describe('save', function() {
@@ -20,13 +85,12 @@ describe('Projects Controllers', function() {
 
         it ("calls go with the correct arguments", function() {
           expect(mockState.go).toHaveBeenCalledWith("root.inner.project", {id: "1"});
-        })
-      })
-    })
-  })
+        });
+      });
+    });
+  });
 
   describe("ProjectNewController", function() {
-    var controller
     var mockRelayer, mockResources, mockState, mockCurrentUser;
 
     beforeEach(function() {
@@ -42,7 +106,7 @@ describe('Projects Controllers', function() {
         user: {
           id: 1
         }
-      }
+      };
 
       controller = new ProjectNewController(mockResources, mockState,
                                             mockCurrentUser);

--- a/frontend/test/projects/projectsControllers.js
+++ b/frontend/test/projects/projectsControllers.js
@@ -5,7 +5,7 @@ describe("Projects Controllers", function() {
 
   describe("ProjectNewController", function() {
     var controller
-    var mockRelayer, mockResources, mockState;
+    var mockRelayer, mockResources, mockState, mockCurrentUser;
 
     beforeEach(function() {
       mockRelayer = jasmine.createSpyObj("mockRelayer", ["new", "create"]);
@@ -16,7 +16,14 @@ describe("Projects Controllers", function() {
 
       mockState = jasmine.createSpyObj("mockState", ["go"]);
 
-      controller = new ProjectNewController(mockResources, mockState);
+      mockCurrentUser = {
+        user: {
+          id: 1
+        }
+      }
+
+      controller = new ProjectNewController(mockResources, mockState,
+                                            mockCurrentUser);
     });
 
     describe("on initialization", function() {
@@ -30,6 +37,7 @@ describe("Projects Controllers", function() {
         var mockPromise, mockProject;
 
         beforeEach(function() {
+          controller.project = {};
           mockProject = {shortLink: "3"};
           mockPromise = Promise.resolve(mockProject);
           mockRelayer.create.and.returnValue(mockPromise);


### PR DESCRIPTION
Adds a current-user service based on ng-token-auth, not Xing Relayer. As a result, user information in the frontend is stored in userId, not in a reference link. 

Creating and editing users is checked using CanCan in the backend, and in the frontend, the current user is checked for displaying create and edit buttons.

The "user edits a project" spec is not running correctly when part of a group of specs, but responds correctly (and currently passes) when run individually.
